### PR TITLE
add playlist support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -128,8 +128,8 @@ dmypy.json
 # Pyre type checker
 .pyre/
 
+/deps/
 /attic/
-/pjproject/
 .idea
 /ha-sip/src/config_local.py
 /incoming.yaml

--- a/README.md
+++ b/README.md
@@ -203,10 +203,10 @@ menu:
     id: main # If "id" is present, a message will be sent via webhook (entered_menu), see below (optional)
     message: Please enter your access code # the message to be played via TTS (optional, defaults to empty)
     playlist: # (optional)
-        # items must begin with 'message:' or 'audio_file:'. 
-        # items must be put into quotes
-        - "message: Hello World!"
-        - "audio_file: /config/audio/welcome.mp3"
+        - type: message
+          value: Hello World!
+        - type: audio_file
+          value: ''/config/audio/welcome.mp3'
     language: en # TTS language (optional, defaults to the global language from add-on config)
     choices_are_pin: true # If the choices should be handled like PINs (optional, defaults to false)
     timeout: 10 # time in seconds before "timeout" choice is triggered (optional, defaults to 300)

--- a/README.md
+++ b/README.md
@@ -165,6 +165,8 @@ Example content of `/config/sip-1-incoming.yaml`:
 allowed_numbers: # list of numbers which will be answered. If removed all numbers will be accepted
     - "5551234456"
     - "5559876543"
+    - "555{*}" # matches every number starting with 555
+    - "555{?}" # matches every number starting with 555 which is 4 digits long
 # blocked_numbers: # alternatively you can specify the numbers not to be answered. You can't have both.
 #    - "5551234456"
 #    - "5559876543"
@@ -207,9 +209,10 @@ menu:
     timeout: 10 # time in seconds before "timeout" choice is triggered (optional, defaults to 300)
     post_action: noop # this action will be triggered after the message was played. Can be 
                       # "noop" (do nothing), 
-                      # "return" (makes only sense in a sub-menu), 
+                      # "return <level>" (makes only sense in a sub-menu, returns <level> levels, defaults to 1), 
                       # "hangup" (hang-up the call) and
                       # "repeat_message" (repeat the message until the time-out is reached)
+                      # "jump <menu-id>" (jumps to menu with id <menu-id>)
                       # (optional, defaults to noop)
     action: # action to run when menu was entered (before playing the message) (optional)
         # For details visit https://developers.home-assistant.io/docs/api/rest/, POST on /api/services/<domain>/<service>
@@ -227,7 +230,7 @@ menu:
             post_action: hangup
         '7777':
             audio_file: '/config/audio/welcome.mp3' # audio file to be played (.wav or .mp3).
-            post_action: hangup
+            post_action: jump owner # jump to menu id 'owner'
         'default': # this will be triggered if the input does not match any specified choice
             id: wrong_code
             message: Wrong code, please try again

--- a/README.md
+++ b/README.md
@@ -203,10 +203,10 @@ menu:
     id: main # If "id" is present, a message will be sent via webhook (entered_menu), see below (optional)
     message: Please enter your access code # the message to be played via TTS (optional, defaults to empty)
     playlist: # (optional)
-        - type: message
-          value: Hello World!
+        - type: tts
+          message: Hello World!
         - type: audio_file
-          value: ''/config/audio/welcome.mp3'
+          audio_file: /config/audio/welcome.mp3'
     language: en # TTS language (optional, defaults to the global language from add-on config)
     choices_are_pin: true # If the choices should be handled like PINs (optional, defaults to false)
     timeout: 10 # time in seconds before "timeout" choice is triggered (optional, defaults to 300)

--- a/README.md
+++ b/README.md
@@ -202,14 +202,21 @@ used for incoming and outgoing calls.
 menu:
     id: main # If "id" is present, a message will be sent via webhook (entered_menu), see below (optional)
     message: Please enter your access code # the message to be played via TTS (optional, defaults to empty)
+    playlist: # (optional)
+        # items must begin with 'message:' or 'audio_file:'. 
+        # items must be put into quotes
+        - "message: Hello World!"
+        - "audio_file: /config/audio/welcome.mp3"
     language: en # TTS language (optional, defaults to the global language from add-on config)
     choices_are_pin: true # If the choices should be handled like PINs (optional, defaults to false)
     timeout: 10 # time in seconds before "timeout" choice is triggered (optional, defaults to 300)
+    repeat_wait: 2 # time in seconds to wait before repeating a message/playlist (optional, defaults to 0 seconds)
     post_action: noop # this action will be triggered after the message was played. Can be 
                       # "noop" (do nothing), 
                       # "return" (makes only sense in a sub-menu), 
                       # "hangup" (hang-up the call) and
-                      # "repeat_message" (repeat the message until the time-out is reached)
+                      # "repeat_message" (repeat the message or last playlist item until the time-out is reached)
+                      # "repeat_playlist" (repeat the whole playlist until the time-out is reached)
                       # (optional, defaults to noop)
     action: # action to run when menu was entered (before playing the message) (optional)
         # For details visit https://developers.home-assistant.io/docs/api/rest/, POST on /api/services/<domain>/<service>

--- a/README.md
+++ b/README.md
@@ -165,6 +165,8 @@ Example content of `/config/sip-1-incoming.yaml`:
 allowed_numbers: # list of numbers which will be answered. If removed all numbers will be accepted
     - "5551234456"
     - "5559876543"
+    - "555{*}" # matches every number starting with 555
+    - "555{?}" # matches every number starting with 555 which is 4 digits long
 # blocked_numbers: # alternatively you can specify the numbers not to be answered. You can't have both.
 #    - "5551234456"
 #    - "5559876543"
@@ -213,10 +215,11 @@ menu:
     repeat_wait: 2 # time in seconds to wait before repeating a message/playlist (optional, defaults to 0 seconds)
     post_action: noop # this action will be triggered after the message was played. Can be 
                       # "noop" (do nothing), 
-                      # "return" (makes only sense in a sub-menu), 
+                      # "return <level>" (makes only sense in a sub-menu, returns <level> levels, defaults to 1), 
                       # "hangup" (hang-up the call) and
                       # "repeat_message" (repeat the message or last playlist item until the time-out is reached)
                       # "repeat_playlist" (repeat the whole playlist until the time-out is reached)
+                      # "jump <menu-id>" (jumps to menu with id <menu-id>)
                       # (optional, defaults to noop)
     action: # action to run when menu was entered (before playing the message) (optional)
         # For details visit https://developers.home-assistant.io/docs/api/rest/, POST on /api/services/<domain>/<service>
@@ -234,7 +237,7 @@ menu:
             post_action: hangup
         '7777':
             audio_file: '/config/audio/welcome.mp3' # audio file to be played (.wav or .mp3).
-            post_action: hangup
+            post_action: jump owner # jump to menu id 'owner'
         'default': # this will be triggered if the input does not match any specified choice
             id: wrong_code
             message: Wrong code, please try again

--- a/build.sh
+++ b/build.sh
@@ -11,6 +11,8 @@ if [ -z "$DOCKER_HUB_PASSWORD" ]
     exit 1
 fi
 
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd)
+
 case "$1" in
     build-next)
         echo "Building on next repo (aarch64 only)..."
@@ -59,19 +61,22 @@ case "$1" in
         ;;
     test)
         echo "Running type-check..."
+        python3 -m unittest discover -s "$SCRIPT_DIR"/ha-sip/src
         pyright ha-sip
         ;;
+    run-local)
+        "$SCRIPT_DIR"/ha-sip/src/main.py local
+        ;;
     create-venv)
-        SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd)
-        rm -rf $SCRIPT_DIR/venv $SCRIPT_DIR/deps
-        python3 -m venv $SCRIPT_DIR/venv
-        source $SCRIPT_DIR/venv/bin/activate
+        rm -rf "$SCRIPT_DIR"/venv "$SCRIPT_DIR"/deps
+        python3 -m venv "$SCRIPT_DIR"/venv
+        source "$SCRIPT_DIR"/venv/bin/activate
         pip3 install pydub requests PyYAML typing_extensions
-        mkdir $SCRIPT_DIR/deps
-        cd $SCRIPT_DIR/deps || exit
+        mkdir "$SCRIPT_DIR"/deps
+        cd "$SCRIPT_DIR"/deps || exit
         git clone --depth 1 --branch 2.13 https://github.com/pjsip/pjproject.git
         cd pjproject || exit
-        ./configure --enable-shared --disable-libwebrtc --prefix $SCRIPT_DIR/venv
+        ./configure --enable-shared --disable-libwebrtc --prefix "$SCRIPT_DIR"/venv
         make
         make dep
         make install

--- a/build.sh
+++ b/build.sh
@@ -60,8 +60,9 @@ case "$1" in
         docker pull homeassistant/amd64-builder:dev
         ;;
     test)
-        echo "Running type-check..."
+        echo "Running unit tests..."
         python3 -m unittest discover -s "$SCRIPT_DIR"/ha-sip/src
+        echo "Running type-check..."
         pyright ha-sip
         ;;
     run-local)

--- a/ha-sip/CHANGELOG.md
+++ b/ha-sip/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## 2.7
+
+- Added option to play a list of messages and/or audio files
+- Added option `repeat_playlist` to `post_action`: repeat whole playlist. `repeat_message` will repeat only the last item in case of a playlist.
+- Added option `repeat_wait` for an extra delay between repeated messages (in seconds).
+  ```yaml
+    menu:
+        playlist:
+            - "message: Hello World!"
+            - "audio_file: /config/audio/welcome.mp3"
+        post_action: "repeat_playlist"
+        repeat_wait: 2
+    ```
+
 ## 2.6
 - Call additional web-hooks for incoming and outgoing calls
 #### Deprecation notice: `webhook_to_call_after_call_was_established` will be removed in the next release and is replaced by the more granular `webhook_to_call`.

--- a/ha-sip/CHANGELOG.md
+++ b/ha-sip/CHANGELOG.md
@@ -1,7 +1,6 @@
 # Changelog
 
-## 2.7
-
+## 2.8
 - Added option to play a list of messages and/or audio files
 - Added option `repeat_playlist` to `post_action`: repeat whole playlist. `repeat_message` will repeat only the last item in case of a playlist.
 - Added option `repeat_wait` for an extra delay between repeated messages (in seconds).
@@ -15,6 +14,12 @@
         post_action: "repeat_playlist"
         repeat_wait: 2
     ```
+
+## 2.7
+- More flexible `return` post action: specify how many levels to go back from the sub-menu
+- Added `jump` post action to jump to any menu with an id
+- Add wildcard support for incoming call `allowed_numbers` and `blocked_numbers` filter
+- Bugfix: time-out not reset when returning to parent menu
 
 ## 2.6
 - Call additional web-hooks for incoming and outgoing calls

--- a/ha-sip/CHANGELOG.md
+++ b/ha-sip/CHANGELOG.md
@@ -8,10 +8,10 @@
   ```yaml
     menu:
         playlist:
-            - type: message
-              value: "Hello World!"
+            - type: tts
+              message: "Hello World!"
             - type: audio_file
-              value: "/config/audio/welcome.mp3"
+              audio_file: "/config/audio/welcome.mp3"
         post_action: "repeat_playlist"
         repeat_wait: 2
     ```

--- a/ha-sip/CHANGELOG.md
+++ b/ha-sip/CHANGELOG.md
@@ -4,6 +4,7 @@
 - More flexible `return` post action: specify how many levels to go back from the sub-menu
 - Added `jump` post action to jump to any menu with an id
 - Add wildcard support for incoming call `allowed_numbers` and `blocked_numbers` filter
+- Bugfix: time-out not reset when returning to parent menu
 
 ## 2.6
 - Call additional web-hooks for incoming and outgoing calls

--- a/ha-sip/CHANGELOG.md
+++ b/ha-sip/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2.7
+- More flexible `return` post action: specify how many levels to go back from the sub-menu
+- Added `jump` post action to jump to any menu with an id
+- Add wildcard support for incoming call `allowed_numbers` and `blocked_numbers` filter
+
 ## 2.6
 - Call additional web-hooks for incoming and outgoing calls
 #### Deprecation notice: `webhook_to_call_after_call_was_established` will be removed in the next release and is replaced by the more granular `webhook_to_call`.

--- a/ha-sip/CHANGELOG.md
+++ b/ha-sip/CHANGELOG.md
@@ -8,8 +8,10 @@
   ```yaml
     menu:
         playlist:
-            - "message: Hello World!"
-            - "audio_file: /config/audio/welcome.mp3"
+            - type: message
+              value: "Hello World!"
+            - type: audio_file
+              value: "/config/audio/welcome.mp3"
         post_action: "repeat_playlist"
         repeat_wait: 2
     ```

--- a/ha-sip/config.json
+++ b/ha-sip/config.json
@@ -1,6 +1,6 @@
 {
     "name": "ha-sip",
-    "version": "2.6",
+    "version": "2.7",
     "slug": "ha-sip",
     "url": "https://github.com/arnonym/ha-plugins",
     "description": "Home-Assistant SIP Gateway",

--- a/ha-sip/config.json
+++ b/ha-sip/config.json
@@ -1,6 +1,6 @@
 {
     "name": "ha-sip",
-    "version": "2.6",
+    "version": "2.8",
     "slug": "ha-sip",
     "url": "https://github.com/arnonym/ha-plugins",
     "description": "Home-Assistant SIP Gateway",

--- a/ha-sip/src/audio.py
+++ b/ha-sip/src/audio.py
@@ -8,7 +8,6 @@ import pydub
 
 
 def convert_audio_to_wav(audio_file_name: str, parameters: Optional[list] = None) -> Optional[str]:
-
     def get_audio_segment(file_name: str) -> Optional[pydub.AudioSegment]:
         _, file_extension = os.path.splitext(file_name)
         if file_extension == '.mp3':

--- a/ha-sip/src/audio.py
+++ b/ha-sip/src/audio.py
@@ -7,7 +7,8 @@ from typing import Optional
 import pydub
 
 
-def convert_audio_to_wav(audio_file_name: str) -> Optional[str]:
+def convert_audio_to_wav(audio_file_name: str, parameters: Optional[list] = None) -> Optional[str]:
+
     def get_audio_segment(file_name: str) -> Optional[pydub.AudioSegment]:
         _, file_extension = os.path.splitext(file_name)
         if file_extension == '.mp3':
@@ -25,7 +26,7 @@ def convert_audio_to_wav(audio_file_name: str) -> Optional[str]:
     if not audio_segment:
         print('Error: could not figure out file format (.mp3, .ogg, .wav is supported):', audio_file_name)
         return None
-    audio_segment.export(wave_file_handler.name, format='wav')
+    audio_segment.export(wave_file_handler.name, format='wav', parameters=parameters if parameters else None)
     return wave_file_handler.name
 
 

--- a/ha-sip/src/call.py
+++ b/ha-sip/src/call.py
@@ -212,7 +212,7 @@ class Call(pj.Call):
     def handle_connected_state(self):
         log(self.account.config.index, 'Call is established.')
         self.connected = True
-        self.last_seen = time.time()
+        self.reset_timeout()
         if self.webhook_to_call:
             ha.trigger_webhook(self.ha_config, {
                 'event': 'call_established',
@@ -273,7 +273,7 @@ class Call(pj.Call):
             if self.player:
                 self.player.stopTransmit(self.audio_media)
             self.playback_is_done = True
-        self.last_seen = time.time()
+        self.reset_timeout()
         self.pressed_digit_list.append(prm.digit)
 
     def handle_dtmf_digit(self, pressed_digit: str) -> None:
@@ -332,6 +332,7 @@ class Call(pj.Call):
         log(self.account.config.index, 'onCallRedirected')
 
     def handle_menu(self, menu: Optional[Menu], send_webhook_event=True, handle_action=True, reset_input=True) -> None:
+        self.reset_timeout()
         if not menu:
             log(self.account.config.index, 'No menu supplied')
             return
@@ -417,7 +418,7 @@ class Call(pj.Call):
         self.answer_at = time.time()
 
     def send_dtmf(self, digits: str, method: DtmfMethod = 'in_band') -> None:
-        self.last_seen = time.time()
+        self.reset_timeout()
         log(self.account.config.index, 'Sending DTMF %s' % digits)
         if method == 'in_band':
             if not self.tone_gen:
@@ -455,6 +456,9 @@ class Call(pj.Call):
             'local_uri': ci.localUri,
             'parsed_caller': parsed_caller,
         }
+
+    def reset_timeout(self):
+        self.last_seen = time.time()
 
     def normalize_menu(self, menu: MenuFromStdin, parent_menu: Optional[Menu] = None, is_default_or_timeout_choice=False) -> Menu:
         def parse_post_action(action: Optional[str]) -> PostAction:

--- a/ha-sip/src/call.py
+++ b/ha-sip/src/call.py
@@ -302,6 +302,30 @@ class Call(pj.Call):
                     log(self.account.config.index, 'Invalid input %s' % self.current_input)
                     self.handle_menu(self.menu['default_choice'])
 
+    def onCallTransferRequest(self, prm):
+        log(self.account.config.index, 'onCallTransferRequest')
+
+    def onCallTransferStatus(self, prm):
+        log(self.account.config.index, 'onCallTransferStatus')
+
+    def onCallReplaceRequest(self, prm):
+        log(self.account.config.index, 'onCallReplaceRequest')
+
+    def onCallReplaced(self, prm):
+        log(self.account.config.index, 'onCallReplaced')
+
+    def onCallRxOffer(self, prm):
+        log(self.account.config.index, 'onCallRxOffer')
+
+    def onCallRxReinvite(self, prm):
+        log(self.account.config.index, 'onCallRxReinvite')
+
+    def onCallTxOffer(self, prm):
+        log(self.account.config.index, 'onCallTxOffer')
+
+    def onCallRedirected(self, prm):
+        log(self.account.config.index, 'onCallRedirected')
+
     def handle_menu(self, menu: Optional[Menu], send_webhook_event=True, handle_action=True, reset_input=True) -> None:
         if not menu:
             log(self.account.config.index, 'No menu supplied')

--- a/ha-sip/src/main.py
+++ b/ha-sip/src/main.py
@@ -165,11 +165,10 @@ def main():
             is_first_enabled_account = False
     command_server = command_client.CommandClient()
     while True:
-        if end_point:
-            end_point.libHandleEvents(20)
-            handle_command_list(command_server, end_point, sip_accounts, call_state, ha_config)
-            for c in list(call_state.current_call_dict.values()):
-                c.handle_events()
+        end_point.libHandleEvents(20)
+        handle_command_list(command_server, end_point, sip_accounts, call_state, ha_config)
+        for c in list(call_state.current_call_dict.values()):
+            c.handle_events()
 
 
 if __name__ == '__main__':

--- a/ha-sip/src/main.py
+++ b/ha-sip/src/main.py
@@ -165,10 +165,11 @@ def main():
             is_first_enabled_account = False
     command_server = command_client.CommandClient()
     while True:
-        end_point.libHandleEvents(20)
-        handle_command_list(command_server, end_point, sip_accounts, call_state, ha_config)
-        for c in list(call_state.current_call_dict.values()):
-            c.handle_events()
+        if end_point:
+            end_point.libHandleEvents(20)
+            handle_command_list(command_server, end_point, sip_accounts, call_state, ha_config)
+            for c in list(call_state.current_call_dict.values()):
+                c.handle_events()
 
 
 if __name__ == '__main__':

--- a/ha-sip/src/player.py
+++ b/ha-sip/src/player.py
@@ -18,3 +18,7 @@ class Player(pj.AudioMediaPlayer):
     def play_file(self, audio_media: pj.AudioMedia, sound_file_name: str) -> None:
         self.createPlayer(file_name=sound_file_name, options=pj.PJMEDIA_FILE_NO_LOOP)
         self.startTransmit(audio_media)
+
+    def play_playlist(self, audio_media: pj.AudioMedia, wav_playlist: list) -> None:
+        self.createPlaylist(wav_playlist, "thePlaylist", pj.PJMEDIA_FILE_NO_LOOP)
+        self.startTransmit(audio_media)

--- a/ha-sip/src/tests/test_account.py
+++ b/ha-sip/src/tests/test_account.py
@@ -1,0 +1,21 @@
+import unittest
+from account import Account
+
+
+class AccountTest(unittest.TestCase):
+    def test_is_number_in_list(self):
+        self.assertEqual(Account.is_number_in_list(None, ["12345"]), False)
+        self.assertEqual(Account.is_number_in_list(None, []), False)
+        self.assertEqual(Account.is_number_in_list("12345", []), False)
+        self.assertEqual(Account.is_number_in_list("12345", ["12345"]), True)
+        self.assertEqual(Account.is_number_in_list("1234", ["12345"]), False)
+        self.assertEqual(Account.is_number_in_list("123456", ["1234{*}"]), True)
+        self.assertEqual(Account.is_number_in_list("123456", ["1234{?}"]), False)
+        self.assertEqual(Account.is_number_in_list("12345", ["1234{?}"]), True)
+        self.assertEqual(Account.is_number_in_list("12345", ["1{*}5"]), True)
+        self.assertEqual(Account.is_number_in_list("12345", ["12{?}45"]), True)
+        self.assertEqual(Account.is_number_in_list("12345", ["{*}45"]), True)
+        self.assertEqual(Account.is_number_in_list("12345", ["{?}345"]), False)
+        self.assertEqual(Account.is_number_in_list("12345", ["{?}2345"]), True)
+        self.assertEqual(Account.is_number_in_list("**620", ["**620"]), True)
+        self.assertEqual(Account.is_number_in_list("**620", ["**{*}"]), True)

--- a/ha-sip/src/utils.py
+++ b/ha-sip/src/utils.py
@@ -15,3 +15,10 @@ def convert_to_float(s: Any, default=0.0) -> float:
     except (ValueError, TypeError):
         return default
     return i
+
+
+def safe_list_get(source_list: list, index: int, default: Any = None) -> Any:
+    try:
+        return source_list[index]
+    except IndexError:
+        return default


### PR DESCRIPTION
- Add option to play a list of messages and/or audio files
- Add option `repeat_playlist` to `post_action`: repeat whole playlist. `repeat_message` will repeat only the last item in case of a playlist.
- Add option `repeat_wait` for an extra delay between repeated messages (in seconds).

closes #37 