### PR TITLE
Allow platforms to directly return wav files.

### DIFF
--- a/ha-sip/src/audio.py
+++ b/ha-sip/src/audio.py
@@ -38,7 +38,7 @@ def convert_mp3_stream_to_wav(stream: bytes) -> Optional[str]:
 
 
 def write_wav_to_file(stream: bytes) -> Optional[str]:
-    wav_file_handler = tempfile.NamedTemporaryFile(suffix=".wav")
+    wav_file_handler = tempfile.NamedTemporaryFile(suffix=".wav", delete=False)
     wav_file_handler.write(stream)
     wav_file_handler.flush()
     return wav_file_handler.name

--- a/ha-sip/src/audio.py
+++ b/ha-sip/src/audio.py
@@ -17,6 +17,7 @@ def convert_audio_to_wav(audio_file_name: str) -> Optional[str]:
         if file_extension == '.wav':
             return pydub.AudioSegment.from_wav(file_name)
         return None
+
     if not os.path.exists(audio_file_name):
         print('Error: could not find audio file:', audio_file_name)
         return None
@@ -34,3 +35,10 @@ def convert_mp3_stream_to_wav(stream: bytes) -> Optional[str]:
     mp3_file_handler.write(stream)
     mp3_file_handler.flush()
     return convert_audio_to_wav(mp3_file_handler.name)
+
+
+def write_wav_to_file(stream: bytes) -> Optional[str]:
+    wav_file_handler = tempfile.NamedTemporaryFile(suffix=".wav")
+    wav_file_handler.write(stream)
+    wav_file_handler.flush()
+    return wav_file_handler.name

--- a/ha-sip/src/ha.py
+++ b/ha-sip/src/ha.py
@@ -96,7 +96,10 @@ def create_and_get_tts(ha_config: HaConfig, message: str, language: str) -> tupl
     response_deserialized = create_response.json()
     mp3_url = response_deserialized['url']
     mp3_response = requests.get(mp3_url, headers=headers)
-    wav_file_name = audio.convert_mp3_stream_to_wav(mp3_response.content)
+    if mp3_url.split(".")[-1] == "mp3":
+        wav_file_name = audio.convert_mp3_stream_to_wav(mp3_response.content)
+    else:
+        wav_file_name = audio.write_wav_to_file(mp3_response.content)
     if not wav_file_name:
         log(None, 'Error converting to wav: %s' % wav_file_name)
         error_file_name = os.path.join(constants.ROOT_PATH, 'sound/answer.wav')


### PR DESCRIPTION
Some platforms return wav files, which breaks the playback. This is especially important if you want to use the new "piper" tts developed by Homeassistant.

- [x] Tested 