### PR TITLE
Add called_number to web-hook.

### DIFF
--- a/ha-sip/src/account.py
+++ b/ha-sip/src/account.py
@@ -119,6 +119,7 @@ class Account(pj.Account):
             'event': 'incoming_call',
             'caller': ci['remote_uri'],
             'parsed_caller': ci['parsed_caller'],
+            'called_number': ci['parsed_called'],
             'sip_account': self.config.index,
             'call_id': ci['call_id'],
             'internal_id': incoming_call_instance.callback_id

--- a/ha-sip/src/call.py
+++ b/ha-sip/src/call.py
@@ -97,6 +97,7 @@ class CallInfo(TypedDict):
     local_uri: str
     remote_uri: str
     parsed_caller: Optional[str]
+    parsed_called: Optional[str]
     call_id: str
 
 
@@ -633,10 +634,12 @@ class Call(pj.Call):
     def get_call_info(self) -> CallInfo:
         ci = self.getInfo()
         parsed_caller = self.parse_caller(ci.remoteUri)
+        parsed_called = self.parse_caller(ci.localUri)
         return {
             'remote_uri': ci.remoteUri,
             'local_uri': ci.localUri,
             'parsed_caller': parsed_caller,
+            'parsed_called': parsed_called,
             'call_id': ci.callIdString,
         }
 

--- a/ha-sip/src/ha.py
+++ b/ha-sip/src/ha.py
@@ -18,6 +18,7 @@ class IncomingCallEvent(TypedDict):
     event: Literal['incoming_call']
     caller: str
     parsed_caller: Optional[str]
+    called_number: Optional[str]
     sip_account: int
     call_id: Optional[str]
     internal_id: str


### PR DESCRIPTION
Hi there,

I think it would be useful to add the number the caller dialed to the incoming call webhook.
You could use a dialplan to send certain numbers to Home Assistant. It can then perform actions based on the number dialed.

Thanks for building this add-on. I like it a lot!

Marnix