### PR TITLE
Incomplete call menus when using default or timeout

### DIFF
--- a/ha-sip/src/call.py
+++ b/ha-sip/src/call.py
@@ -632,8 +632,12 @@ class Call(pj.Call):
             if m['id']:
                 menu_map[m['id']] = m
             if m['choices']:
-                for m in m['choices'].values():
-                    add_to_map(menu_map, m)
+                for choice in m['choices'].values():
+                    add_to_map(menu_map, choice)
+            if m['default_choice']:
+                add_to_map(menu_map, m['default_choice'])
+            if m['timeout_choice']:
+                add_to_map(menu_map, m['timeout_choice'])
             return menu_map
         if not menu:
             return {}


### PR DESCRIPTION
Hi there!

Today I found a bug with incomplete menu mappings as it was not possible to jump to a few specific menu IDs.

A brief analysis revealed that all affected IDs were nested entries behind a `timeout` menu.

Root cause: In `create_menu_map`, the tree is traversed for each menu and its sub-choices. Both `default` and `timeout` are not considered, but they can actually be valid submenus (even with nested menus etc.)
Because of that, any menu ID which comes after a timeout/default menu won't make it into the menu map. And thus will not be a valid jump target for any step of the whole menu definition.

Small example (quite useless, only for demonstration):

```yaml
menu:
  id: main
  message: Please press 1.
  choices:

    "1":
      id: one
      message: You pressed 1. Good for you.
      post_action: jump main

    default:
      id: not_one
      message: You pressed something else. Would you rather press 2?
      choices:
        "2":
          message: Very well played.
        default:
          id: salad
          message: Now we have the salad.
          post_action: jump not_one   # <- will not work

    timeout:
      id: nothing
      message: You did nothing.
      post_action: jump salad    # will not work, too
```

In this example, the menu map will only contain "main" and "one". "not_one" and "nothing" won't be considered, and so "salad" will be missing, too.

I think all entries should be considered to ensure that jumping from anywhere to any possible (sub)menu is always possible. I applied a fix for that, which is very straightforward.

BR
Niklas

